### PR TITLE
AbstractKomaクラスの更新

### DIFF
--- a/AbstractKoma.pde
+++ b/AbstractKoma.pde
@@ -30,13 +30,27 @@ abstract class AbstractKoma {
     rect(this.x*SQUARESIZE, this.y*SQUARESIZE, SQUARESIZE, SQUARESIZE);
   }
   void move(int toX, int toY) {
-    this.updatePos(toX, toY);
+    AbstractKoma koma = komaList.getKomaFromPlace(toX, toY);
+    if (koma==null) this.updatePos(toX, toY);
+    else if (koma.team != gs.turn) this.moveAndCapture(koma, toX, toY);
   }
-  
+
   void updatePos(int toX, int toY) {
     this.x=toX;
     this.y=toY;
+    this.kStat.captured=false;
     gs.turn = (gs.turn+1)%2;
   }
 
+  void moveAndCapture(AbstractKoma enemy, int toX, int toY) {
+    this.updatePos(toX, toY);
+    if (enemy!=null) enemy.captured();
+  }
+
+  void captured() {
+    this.kStat.captured=true;
+    this.team = (this.team+1)%2;
+    this.y = board.mArea[this.team].getBlankYIndex();
+    this.x = board.mArea[this.team].posX;
+  }
 }


### PR DESCRIPTION
AbstractKomaクラスの move() メソッドと updatePos() メソッドを更新し， moveAndCapture()
メソッド， captured() メソッドを追加した。

Leftからスタートし，Left側のコマを移動した後，Right側のコマが移動できるようになり、コマを敵のコマが存在するマス目に移動すると，そのコマが取得され，自陣の持ちゴマエリアに移動し、コマ移動時に自陣のコマが存在するマス目には移動できないようにした。